### PR TITLE
Enhance mobile layout

### DIFF
--- a/src/app/components/ProjectsSection.js
+++ b/src/app/components/ProjectsSection.js
@@ -1,27 +1,15 @@
 'use client'
 import React from "react";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import FullScreenSection from "./FullScreenSection";
 import { Box, Heading, Link } from "@chakra-ui/react";
 import Card from "./Card";
 import { Cube1 } from "./TheCubes"
+import ServiceCards from "./ServiceCards"
 import useIsMobile from "../hooks/isMobile";
 import ProjectsOtherSide from "./ProjectsOtherSide"; 
 
-const Map = 
-  <Box
-    className="flipBox2"
-    w={'100%'}
-    bgColor={'white'}
-    backgroundColor={'white'}
-    display="flex"
-    justifyItems={'center'}
-    alignItems={'center'}
-    >
-        <Card> 
-          <Cube1 />
-        </Card>
-  </Box>
+
 
 
 const ProjectsSection = () => {
@@ -29,33 +17,59 @@ const ProjectsSection = () => {
   const [colors, setColors] = useState({ project: 'black', qualities: 'grey' });
   const [turn, setTurn] = useState('0')
   const [widthOF, SetwidthOF] = useState('0')
-  const  [Content, setContent] = useState(Map)
   const isMobile = useIsMobile();
+  const Map = (
+    <Box
+      className="flipBox2"
+      w={'100%'}
+      bgColor={'white'}
+      backgroundColor={'white'}
+      display="flex"
+      justifyItems={'center'}
+      alignItems={'center'}
+    >
+      {isMobile ? (
+        <ServiceCards />
+      ) : (
+        <Card>
+          <Cube1 />
+        </Card>
+      )}
+    </Box>
+  );
+
+  const [Content, setContent] = useState(Map)
   const button_postion = useIsMobile() ? `flex-end` : `center`;
   const word_length = useIsMobile() ? 250 : 230;
   const [phone_show, setPhone] = useState('none')
 
+  useEffect(() => {
+    setContent(Map);
+  }, [isMobile]);
+
   function handleColorChange() {
-    const startTurn = parseInt(turn, 10);
-    const endTurn = startTurn === 0 ? 180 : 0;
-    const increment = startTurn < endTurn ? 5 : -5;
-  
-    function updateTurn(currentTurn) {
-      if ((increment > 0 && currentTurn < endTurn) || (increment < 0 && currentTurn > endTurn)) {
-        const nextTurn = currentTurn + increment;
-        setTurn(nextTurn.toString());
+    if (isMobile) {
+      setContent(Content === Map ? <ProjectsOtherSide /> : Map);
+    } else {
+      const startTurn = parseInt(turn, 10);
+      const endTurn = startTurn === 0 ? 180 : 0;
+      const increment = startTurn < endTurn ? 5 : -5;
 
-        if (Math.abs(nextTurn) === 90) { 
-          setContent(Content === Map ? <ProjectsOtherSide /> : Map);
-          
+      function updateTurn(currentTurn) {
+        if ((increment > 0 && currentTurn < endTurn) || (increment < 0 && currentTurn > endTurn)) {
+          const nextTurn = currentTurn + increment;
+          setTurn(nextTurn.toString());
 
+          if (Math.abs(nextTurn) === 90) {
+            setContent(Content === Map ? <ProjectsOtherSide /> : Map);
+          }
+
+          setTimeout(() => updateTurn(nextTurn), 10);
         }
-  
-        setTimeout(() => updateTurn(nextTurn), 10); 
       }
+
+      updateTurn(startTurn);
     }
-  
-    updateTurn(startTurn);
     
     setColors({
       project: colors.project === 'black' ? 'grey' : 'black',

--- a/src/app/components/ServiceCards.js
+++ b/src/app/components/ServiceCards.js
@@ -1,0 +1,40 @@
+'use client'
+import { Box, Text, Link, VStack } from '@chakra-ui/react';
+import Image from 'next/image';
+
+const ServiceCard = ({ imageUrl, title, subtitle, link }) => (
+  <Box
+    borderWidth='1px'
+    borderRadius='md'
+    overflow='hidden'
+    w='100%'
+    maxW='400px'
+    bg='white'
+  >
+    <Link href={link}>
+      <Image src={imageUrl} alt={title} width={400} height={200} style={{ width: '100%', height: 'auto' }} />
+      <Box p={4}>
+        <Text fontWeight='bold'>{title}</Text>
+        <Text fontSize='sm'>{subtitle}</Text>
+      </Box>
+    </Link>
+  </Box>
+);
+
+const ServiceCards = () => {
+  const cards = [
+    { title: 'Охрана квартир', subtitle: 'Всего от 7000 тг в месяц...', imageUrl: '/images/flat.png', link: '/kvartity' },
+    { title: 'Охрана домов', subtitle: 'От 8000 тг в месяц...', imageUrl: '/images/home.png', link: '/home' },
+    { title: 'Охрана бизнеса', subtitle: 'От 15 000 тг в месяц...', imageUrl: '/images/bs.png', link: '/business' },
+    { title: 'Особые услуги', subtitle: 'Цена договорная...', imageUrl: '/images/pcar.png', link: '/special_service' },
+  ];
+  return (
+    <VStack w='100%' spacing={4}>
+      {cards.map((card, index) => (
+        <ServiceCard key={index} {...card} />
+      ))}
+    </VStack>
+  );
+};
+
+export default ServiceCards;


### PR DESCRIPTION
## Summary
- add `ServiceCards` component for mobile users
- update `ProjectsSection` to switch between 3D cube and rectangular cards on mobile

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_6845d6fd6b30832b8a648dc31dc30327