### PR TITLE
Responsive cube geometry, preload Why-box images, and cube performance fixes

### DIFF
--- a/src/app/components/Cube.js
+++ b/src/app/components/Cube.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, memo } from 'react';
 import { Box, Text, VStack, HStack } from '@chakra-ui/react';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -22,7 +22,7 @@ const Styles = ({ color, width, height, font, transform }) => ({
   userSelect: 'none',
 });
 
-const CubeFace = ({ color, width, height, font, transform, text, TypeText, imageUrl, speed, textColour, 
+const CubeFace = memo(({ color, width, height, font, transform, text, TypeText, imageUrl, speed, textColour, 
   main_text_color='white', 
   link='/kvartity' }) => (
   <Box sx={Styles({ color, width, height, font, transform })}
@@ -32,9 +32,9 @@ const CubeFace = ({ color, width, height, font, transform, text, TypeText, image
         <Image
           src={imageUrl}
           alt="Cube Face"
-          width="180"
-          height="180"
-          sizes="100vw"
+          width={180}
+          height={180}
+          sizes="(max-width: 900px) 45vw, 180px"
         />
       )}
       {text && <Link
@@ -62,7 +62,7 @@ const CubeFace = ({ color, width, height, font, transform, text, TypeText, image
       )}
     </VStack>
   </Box>
-);
+));
 
 const Cube = ({ faces }) => {
   const [rotation, setRotation] = useState({ rotateX: -30, rotateY: 30 });
@@ -104,7 +104,7 @@ const Cube = ({ faces }) => {
   const animateCube = () => {
     if (!isInteracting) {
       setRotation((prev) => ({
-        rotateX: prev.rotateX = - 20,
+        rotateX: -20,
         rotateY: prev.rotateY + 0.3,
       }));
     }
@@ -137,7 +137,7 @@ const Cube = ({ faces }) => {
           height: '32ch',
           transformStyle: 'preserve-3d',
           transform: `rotateX(${rotation.rotateX}deg) rotateY(${rotation.rotateY}deg)`,
-          transition: 'transform 0.1s linear',
+          transition: isInteracting ? 'none' : 'transform 0.1s linear',
           userSelect: 'none',
         }}
         className="Cube"

--- a/src/app/components/ProjectsOtherSide.js
+++ b/src/app/components/ProjectsOtherSide.js
@@ -1,24 +1,15 @@
 'use client'
 import React from "react";
-import { Box, Heading  } from "@chakra-ui/react";
+import { Box } from "@chakra-ui/react";
 import useismobile from "@/hooks/isMobile";
-
-
-let img1 = "/images/kkorgau3.jpg";
-
-let img2 = "/images/kkorgau24.jpg"
-
-let img3 = '/images/k_standart_enhanced.jpg'
-
-let img4 = '/images/охрана кв куб.jpg'
-
-
-
 import Image from "next/image";
 
-const Why_box = ({ text, img, text2, dark = 'rgba(0, 0, 0, 0.5)' }) => {
-  const ismobile = useismobile();
+let img1 = "/images/kkorgau3.jpg";
+let img2 = "/images/kkorgau24.jpg";
+let img3 = '/images/k_standart_enhanced.jpg';
+let img4 = '/images/охрана кв куб.jpg';
 
+const Why_box = ({ text, img, text2, ismobile, dark = 'rgba(0, 0, 0, 0.5)' }) => {
   return (
     <Box
       display="flex"
@@ -39,13 +30,13 @@ const Why_box = ({ text, img, text2, dark = 'rgba(0, 0, 0, 0.5)' }) => {
         width="100%"
         overflow="hidden"
         borderTopLeftRadius={"2.5%"}
-        borderTopRightRadius={ "2.5%"}
+        borderTopRightRadius={"2.5%"}
       >
         <Image
           src={img}
           alt={text}
-          layout="fill"
-          objectFit="cover"
+          fill
+          style={{ objectFit: 'cover' }}
           priority
         />
         <Box
@@ -101,7 +92,6 @@ const Why_box = ({ text, img, text2, dark = 'rgba(0, 0, 0, 0.5)' }) => {
         bg="rgb(252, 223, 94)"
         w="100%"
         textAlign="center"
-
       >
         {text2}
       </Box>
@@ -109,11 +99,8 @@ const Why_box = ({ text, img, text2, dark = 'rgba(0, 0, 0, 0.5)' }) => {
   );
 };
 
-
-
 const ProjectsOtherSide = () => {
-
-  const ismobile = useismobile()
+  const ismobile = useismobile();
 
   return (
     <Box
@@ -122,27 +109,34 @@ const ProjectsOtherSide = () => {
       display="flex"
       justifyContent={'space-around'}
       width="100%"
-      flexDirection={ismobile ? 'column' : 'raw'}
+      flexDirection={ismobile ? 'column' : 'row'}
       h={['auto', '500']}
-
     >
-          <Why_box 
-          text="Нам доверяют даже конкуренты" 
-          img={img3} 
-          text2="20+ компаний выбрали нас для аутсорса охраны своих объектов" 
-          dark="rgba(0, 0, 0, 0.25)"
-          />
-          <Why_box text="Сомневаетесь в нас? Выйдите на улицу и убедитесь сами" 
-          img={img4} 
-          text2="тысячи наших стикеров по всему городу показатель качества" />
-          <Why_box 
-          text="Залог нашего успеха" 
-          img={img1} 
-          text2=" профессионализм бойцов и передовое оборудование" />
-          <Why_box 
-          text="Более 20 лет успешной работы в Алматы и Астане" 
-          img={img2} 
-          text2="десятки тысяч клиентов уже выбрали нас" />
+      <Why_box
+        ismobile={ismobile}
+        text="Нам доверяют даже конкуренты"
+        img={img3}
+        text2="20+ компаний выбрали нас для аутсорса охраны своих объектов"
+        dark="rgba(0, 0, 0, 0.25)"
+      />
+      <Why_box
+        ismobile={ismobile}
+        text="Сомневаетесь в нас? Выйдите на улицу и убедитесь сами"
+        img={img4}
+        text2="тысячи наших стикеров по всему городу показатель качества"
+      />
+      <Why_box
+        ismobile={ismobile}
+        text="Залог нашего успеха"
+        img={img1}
+        text2=" профессионализм бойцов и передовое оборудование"
+      />
+      <Why_box
+        ismobile={ismobile}
+        text="Более 20 лет успешной работы в Алматы и Астане"
+        img={img2}
+        text2="десятки тысяч клиентов уже выбрали нас"
+      />
     </Box>
   );
 };

--- a/src/app/components/ProjectsSection.js
+++ b/src/app/components/ProjectsSection.js
@@ -1,68 +1,77 @@
 'use client'
-import React from "react";
-import { useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import FullScreenSection from "./FullScreenSection";
-import { Box, Heading, Link } from "@chakra-ui/react";
+import { Box, Heading } from "@chakra-ui/react";
 import Card from "./Card";
-import { Cube1 } from "./TheCubes"
+import { Cube1 } from "./TheCubes";
 import useIsMobile from "../hooks/isMobile";
-import ProjectsOtherSide from "./ProjectsOtherSide"; 
+import ProjectsOtherSide from "./ProjectsOtherSide";
 
-const Map = 
-  <Box
-    className="flipBox2"
-    w={'100%'}
-    bgColor={'white'}
-    backgroundColor={'white'}
-    display="flex"
-    justifyItems={'center'}
-    alignItems={'center'}
-    >
-        <Card> 
-          <Cube1 />
-        </Card>
-  </Box>
-
+const WHY_BOX_IMAGES = [
+  '/images/k_standart_enhanced.jpg',
+  '/images/охрана кв куб.jpg',
+  '/images/kkorgau3.jpg',
+  '/images/kkorgau24.jpg',
+];
 
 const ProjectsSection = () => {
-
   const [colors, setColors] = useState({ project: 'black', qualities: 'grey' });
-  const [turn, setTurn] = useState('0')
-  const [widthOF, SetwidthOF] = useState('0')
-  const  [Content, setContent] = useState(Map)
+  const [turn, setTurn] = useState('0');
+  const [isServicesSide, setIsServicesSide] = useState(true);
   const isMobile = useIsMobile();
-  const button_postion = useIsMobile() ? `flex-end` : `center`;
-  const word_length = useIsMobile() ? 250 : 230;
-  const [phone_show, setPhone] = useState('none')
+
+  const button_postion = isMobile ? `flex-end` : `center`;
+  const word_length = isMobile ? 250 : 230;
+
+  const mapContent = useMemo(() => (
+    <Box
+      className="flipBox2"
+      w={'100%'}
+      bgColor={'white'}
+      backgroundColor={'white'}
+      display="flex"
+      justifyItems={'center'}
+      alignItems={'center'}
+    >
+      <Card>
+        <Cube1 />
+      </Card>
+    </Box>
+  ), []);
+
+  useEffect(() => {
+    WHY_BOX_IMAGES.forEach((src) => {
+      const image = new window.Image();
+      image.src = src;
+      image.decode?.().catch(() => {});
+    });
+  }, []);
 
   function handleColorChange() {
     const startTurn = parseInt(turn, 10);
     const endTurn = startTurn === 0 ? 180 : 0;
     const increment = startTurn < endTurn ? 5 : -5;
-  
+
     function updateTurn(currentTurn) {
       if ((increment > 0 && currentTurn < endTurn) || (increment < 0 && currentTurn > endTurn)) {
         const nextTurn = currentTurn + increment;
         setTurn(nextTurn.toString());
 
-        if (Math.abs(nextTurn) === 90) { 
-          setContent(Content === Map ? <ProjectsOtherSide /> : Map);
-          
-
+        if (Math.abs(nextTurn) === 90) {
+          setIsServicesSide((prev) => !prev);
         }
-  
-        setTimeout(() => updateTurn(nextTurn), 10); 
+
+        setTimeout(() => updateTurn(nextTurn), 10);
       }
     }
-  
+
     updateTurn(startTurn);
-    
+
     setColors({
       project: colors.project === 'black' ? 'grey' : 'black',
       qualities: colors.qualities === 'grey' ? 'black' : 'grey',
     });
   }
-
 
   return (
     <FullScreenSection
@@ -70,64 +79,63 @@ const ProjectsSection = () => {
       p={8}
       spacing={8}
       minHeight={'80vh'}
-    > <Box>
+    >
+      <Box>
         <Box
-        display={'inline-flex'}
-        w={'80vw'}
-        justifyContent={'space-around'}
-        h={20}
+          display={'inline-flex'}
+          w={'80vw'}
+          justifyContent={'space-around'}
+          h={20}
         >
-                    <Box
-                    display={'flex'}
-                    alignItems={button_postion}
-                    justifyItems={'center'}
-                    flexDirection={'column'}
-                    w={'100vw'}
-                    >
-                        <Heading 
-                              as="h5" 
-                              id="projects-section" 
-                              color={colors.project}
-                              height={10}
-                              w={250}
-                              onClick={() => handleColorChange()}
-                      
-                                >
-                              Наши услуги
-                        </Heading>
-                        <Heading 
-                              as="h5" 
-                              id="projects-section" 
-                              color={colors.qualities}
-                              height={10}
-                              mt={10}
-                              w={word_length}
-                              onClick={() => handleColorChange()}
-                        
-                        >
-                          Почему мы
-                          </Heading>
-                    </Box>
-
-            </Box>
+          <Box
+            display={'flex'}
+            alignItems={button_postion}
+            justifyItems={'center'}
+            flexDirection={'column'}
+            w={'100vw'}
+          >
+            <Heading
+              as="h5"
+              id="projects-section"
+              color={colors.project}
+              height={10}
+              w={250}
+              onClick={() => handleColorChange()}
+            >
+              Наши услуги
+            </Heading>
+            <Heading
+              as="h5"
+              id="projects-section"
+              color={colors.qualities}
+              height={10}
+              mt={10}
+              w={word_length}
+              onClick={() => handleColorChange()}
+            >
+              Почему мы
+            </Heading>
+          </Box>
         </Box>
-        <Box
+      </Box>
+      <Box
         display={'flex'}
-        alignContent={['flex-start','center']}
-        justifyContent={['flex-start','center']}
+        alignContent={['flex-start', 'center']}
+        justifyContent={['flex-start', 'center']}
         w={'80vw'}
         mt={20}
-          > <Box
+      >
+        <Box
           display={'flex'}
           alignContent={'flex-start'}
           justifyContent={'flex-start'}
-              sx={{
-                transform: `rotateX(0deg) rotateY(${turn}deg)`,
-              }}
-          > 
-            {Content}
-          </Box>
+          sx={{
+            transform: `rotateX(0deg) rotateY(${turn}deg)`,
+          }}
+        >
+          {isServicesSide ? mapContent : <ProjectsOtherSide />}
         </Box>
+      </Box>
     </FullScreenSection>
   );
 };

--- a/src/app/components/TheCubes.js
+++ b/src/app/components/TheCubes.js
@@ -2,112 +2,103 @@
 import Cube from "./Cube";
 import useismobile from "../hooks/isMobile";
 
-
-let img1 = "/images/kz.png";
-
-let imgB = "/images/kk.jpg";
-
 let img2 = "/images/home.png";
-
 let imgP = "/images/pcar.png";
-
 let imgBS = "/images/bs.png";
-
 let imgF = "/images/flat.png";
 
-let img3 = "/images/бизнес.webp";
-let img4 = "/images/Race.png";
-let img5 = "/images/Дом.webp";
-let img6 = "/images/postgres.png";
-let img7 = "/images/openai.png";
-let img8 = "/images/weather.webp";  
-let img9 = "/images/pshed.webp";
-let img10 = "/images/datasimple.webp";
-let img11 = "/images/pgroup.webp";
-let img12 = "/images/smartt.webp";
-let img13 = "/images/mtasks.webp";
-let img14 = "/images/design.webp";
-let img15 = "/images/onepage.webp";
-let img16 = "/images/modern.webp";
-let img17 = "/images/small.webp";
-let img18 = "/images/webm.webp";
-let img19 = "/images/user.webp";
-let img20 = "/images/bot.webp";
-let img21 = "/images/talk.webp";
-let img22 = "/images/buttons.webp";
-let img23 = "/images/instant.webp";
-let img24 = "/images/discount.webp";
-let img25 = "/images/pythonreact.webp";
-let img26 = "/images/aibot.webp";
-let img27 = "/images/textc.webp";
-let img28 = "/images/3Dimg.webp";
-let img29 = "/images/typeeffect.webp";
-
-
-
-
+const CUBE_GEOMETRY = {
+  desktop: {
+    faceWidth: '30ch',
+    faceHeight: '30ch',
+    topBottomSize: '30ch',
+    depth: '15ch',
+    topDepth: '15ch',
+    bottomDepth: '15ch',
+  },
+  mobile: {
+    faceWidth: '25ch',
+    faceHeight: '33ch',
+    topBottomSize: '25ch',
+    depth: '12.5ch',
+    topDepth: '16.5ch',
+    bottomDepth: '16.5ch',
+  },
+};
 
 export const Cube1 = () => {
-const ismobile = useismobile();
-  const width = ismobile ? `30ch` : `30ch`;
-  const z = ismobile ? `12.5ch` : `15ch`;
-    const cubeFaces = [
-      { color: `rgb(59, 171, 59)`, width: ['25ch','30ch'], height: ['33ch','30ch'], 
-      font: `16px`, 
-      transform: `rotateY(0deg) translateZ(${z})`, 
+  const ismobile = useismobile();
+  const geometry = ismobile ? CUBE_GEOMETRY.mobile : CUBE_GEOMETRY.desktop;
+
+  const cubeFaces = [
+    {
+      color: `rgb(59, 171, 59)`,
+      width: geometry.faceWidth,
+      height: geometry.faceHeight,
+      font: `16px`,
+      transform: `rotateY(0deg) translateZ(${geometry.depth})`,
       text: `Охрана квартир`,
-      TypeText:`Всего от 7000 тг в месяц...`,
+      TypeText: `Всего от 7000 тг в месяц...`,
       imageUrl: imgF,
-      textColour: `wheat`, 
+      textColour: `wheat`,
       speed: 45,
       link: '/kvartity'
     },
-      { 
-      color: `
-  rgb(0, 110, 255)
-      `, 
-      width: ['25ch','30ch'], height: ['33ch','30ch'], 
-      font: `16px`, transform: `rotateY(180deg) translateZ(${z})`,
-      text: `Охрана домов`, 
-      TypeText:`От 8000 тг в месяц...`,
+    {
+      color: `rgb(0, 110, 255)`,
+      width: geometry.faceWidth,
+      height: geometry.faceHeight,
+      font: `16px`,
+      transform: `rotateY(180deg) translateZ(${geometry.depth})`,
+      text: `Охрана домов`,
+      TypeText: `От 8000 тг в месяц...`,
       imageUrl: img2,
-      textColour: `wheat`, 
+      textColour: `wheat`,
       speed: 100,
       link: '/home'
     },
-      { 
-      color: `
-  rgb(0, 68, 255)
-      `, width: ['25ch','30ch'], height: ['33ch','30ch'], font: `16px`, transform: `rotateY(90deg) translateZ(${z})`, 
-      text: `Охрана бизнеса`, 
-      TypeText:`От 15 000 тг в месяц...`,
+    {
+      color: `rgb(0, 68, 255)`,
+      width: geometry.faceWidth,
+      height: geometry.faceHeight,
+      font: `16px`,
+      transform: `rotateY(90deg) translateZ(${geometry.depth})`,
+      text: `Охрана бизнеса`,
+      TypeText: `От 15 000 тг в месяц...`,
       imageUrl: imgBS,
-      textColour: `wheat`, 
+      textColour: `wheat`,
       speed: 90,
       link: '/business'
     },
-      { 
-
-      color: `rgb(81, 196, 148)`, 
-      width: ['25ch','30ch'], height: ['33ch','30ch'], 
-      font: `16px`, transform: `rotateY(-90deg) translateZ(${z})`, 
-      text: `Особые услуги`, 
-      TypeText:`Цена договорная...`,
+    {
+      color: `rgb(81, 196, 148)`,
+      width: geometry.faceWidth,
+      height: geometry.faceHeight,
+      font: `16px`,
+      transform: `rotateY(-90deg) translateZ(${geometry.depth})`,
+      text: `Особые услуги`,
+      TypeText: `Цена договорная...`,
       imageUrl: imgP,
-      textColour: `blue`, 
+      textColour: `blue`,
       speed: 60,
       link: '/special_service'
     },
-      { color: `rgb(252, 226, 114)`, 
-      width: ['25ch','30ch'], 
-      height: ['25ch','30ch'], font: `16px`,
-      transform: `rotateX(90deg) 
-      translateZ(${'12.5ch'})`, 
-      speed: 100 
-    
+    {
+      color: `rgb(252, 226, 114)`,
+      width: geometry.topBottomSize,
+      height: geometry.topBottomSize,
+      font: `16px`,
+      transform: `rotateX(90deg) translateZ(${geometry.topDepth})`,
+      speed: 100
     },
-      { color: `orange`, width: ['20ch','30ch'], height: ['20ch','30ch'], font: `16px`, transform: `rotateX(-90deg) translateZ(${z})`,},
-    ];
-  
-    return <Cube faces={cubeFaces} />;
-  };
+    {
+      color: `orange`,
+      width: geometry.topBottomSize,
+      height: geometry.topBottomSize,
+      font: `16px`,
+      transform: `rotateX(-90deg) translateZ(${geometry.bottomDepth})`,
+    },
+  ];
+
+  return <Cube faces={cubeFaces} />;
+};


### PR DESCRIPTION
### Motivation
- Make the 3D cube component render better on narrow (mobile) viewports by changing cube proportions to a rectangular prism on mobile while preserving the desktop 1:1 cube look. 
- Eliminate flicker during the Projects flip transition by ensuring images used on the flipped side are preloaded before the rotation swap. 
- Improve runtime performance and fix small bugs in cube animation/interaction to make dragging and auto-rotation smoother.

### Description
- Added explicit geometry constants and responsive logic in `src/app/components/TheCubes.js` so face sizes and `translateZ` values derive from `CUBE_GEOMETRY` for `desktop` and `mobile` to produce a rectangular prism on mobile and keep desktop unchanged. 
- Memoized `CubeFace` and removed a direct mutation of `rotateX` in `src/app/components/Cube.js`, adjusted `next/image` sizing, and disabled the transform CSS transition while interacting to reduce jank. 
- Implemented eager preloading of the four `Why_box` images in `src/app/components/ProjectsSection.js` using `new Image()` and `decode()` to avoid on-demand loads during the mid-rotation swap. 
- Fixed layout/usage issues in `ProjectsOtherSide.js` (corrected `flexDirection: 'raw'` → `'row'`, modernized `next/image` usage with `fill` and `objectFit`) and reduced remount churn by memoizing the services map and toggling content with `isServicesSide`.

### Testing
- Ran `npm run dev` and confirmed the dev server started and pages rendered successfully (dev server success). 
- Captured a mobile viewport screenshot using Playwright to validate the mobile rectangular-prism layout (screenshot capture succeeded). 
- Ran `npm run build` which failed in this environment due to inability to fetch the Google Font `Aleo` (font fetch error), so production build could not be validated here. 
- Ran `npm run lint` but it could not complete non-interactively due to the repository's interactive ESLint setup prompt (linting not completed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984b094aedc832b8e055a2bf4690c1f)