### PR TITLE
Make cube responsive (mobile rectangular prism), fix rotation bug, and preload project images

### DIFF
--- a/src/app/components/Cube.js
+++ b/src/app/components/Cube.js
@@ -64,12 +64,14 @@ const CubeFace = ({ color, width, height, font, transform, text, TypeText, image
   </Box>
 );
 
-const Cube = ({ faces }) => {
+const Cube = ({ faces, dimensions }) => {
   const [rotation, setRotation] = useState({ rotateX: -30, rotateY: 30 });
   const [isInteracting, setIsInteracting] = useState(false);
   const isDragging = useRef(false);
   const startPos = useRef({ x: 0, y: 0 });
   const animationFrameRef = useRef(null);
+  const cubeWidth = dimensions?.width ?? '30ch';
+  const cubeHeight = dimensions?.containerHeight ?? '32ch';
 
   const handleStart = (e) => {
     setIsInteracting(true);
@@ -104,7 +106,7 @@ const Cube = ({ faces }) => {
   const animateCube = () => {
     if (!isInteracting) {
       setRotation((prev) => ({
-        rotateX: prev.rotateX = - 20,
+        rotateX: -20,
         rotateY: prev.rotateY + 0.3,
       }));
     }
@@ -133,8 +135,8 @@ const Cube = ({ faces }) => {
       <Box
         sx={{
           position: 'relative',
-          width: '30ch',
-          height: '32ch',
+          width: cubeWidth,
+          height: cubeHeight,
           transformStyle: 'preserve-3d',
           transform: `rotateX(${rotation.rotateX}deg) rotateY(${rotation.rotateY}deg)`,
           transition: 'transform 0.1s linear',

--- a/src/app/components/ProjectsOtherSide.js
+++ b/src/app/components/ProjectsOtherSide.js
@@ -1,5 +1,5 @@
 'use client'
-import React from "react";
+import React, { useEffect } from "react";
 import { Box, Heading  } from "@chakra-ui/react";
 import useismobile from "@/hooks/isMobile";
 
@@ -113,6 +113,20 @@ const Why_box = ({ text, img, text2, dark = 'rgba(0, 0, 0, 0.5)' }) => {
 const ProjectsOtherSide = () => {
 
   const ismobile = useismobile()
+  useEffect(() => {
+    const imageSources = [img1, img2, img3, img4];
+    const preloadedImages = imageSources.map((src) => {
+      const image = new window.Image();
+      image.src = src;
+      return image;
+    });
+
+    return () => {
+      preloadedImages.forEach((image) => {
+        image.src = '';
+      });
+    };
+  }, []);
 
   return (
     <Box

--- a/src/app/components/TheCubes.js
+++ b/src/app/components/TheCubes.js
@@ -49,10 +49,17 @@ let img29 = "/images/typeeffect.webp";
 
 export const Cube1 = () => {
 const ismobile = useismobile();
-  const width = ismobile ? `30ch` : `30ch`;
-  const z = ismobile ? `15ch` : `15ch`;
+  const cubeDimensions = ismobile
+    ? { width: 26, height: 36, depth: 26 }
+    : { width: 30, height: 30, depth: 30 };
+  const width = `${cubeDimensions.width}ch`;
+  const height = `${cubeDimensions.height}ch`;
+  const depth = `${cubeDimensions.depth}ch`;
+  const halfWidth = `${cubeDimensions.width / 2}ch`;
+  const halfHeight = `${cubeDimensions.height / 2}ch`;
+  const halfDepth = `${cubeDimensions.depth / 2}ch`;
     const cubeFaces = [
-      { color: `rgb(252, 226, 114)`, width: width, height: width, font: `16px`, transform: `rotateY(0deg) translateZ(${z})`, 
+      { color: `rgb(252, 226, 114)`, width: width, height: height, font: `16px`, transform: `rotateY(0deg) translateZ(${halfDepth})`, 
       text: `Охрана квартир`,
       TypeText:`Всего от 7000 тг в месяц...`,
       imageUrl: imgF,
@@ -66,8 +73,8 @@ const ismobile = useismobile();
       color: `
   rgb(252, 226, 114)
       `, 
-      width: width, height: width, 
-      font: `16px`, transform: `rotateY(180deg) translateZ(${z})`,
+      width: width, height: height, 
+      font: `16px`, transform: `rotateY(180deg) translateZ(${halfDepth})`,
       text: `Охрана домов`, 
       TypeText:`От 8000 тг в месяц...`,
       imageUrl: img2,
@@ -79,7 +86,7 @@ const ismobile = useismobile();
       { 
       color: `
     rgb(0, 110, 255)
-      `, width: width, height: width, font: `16px`, transform: `rotateY(90deg) translateZ(${z})`, 
+      `, width: depth, height: height, font: `16px`, transform: `rotateY(90deg) translateZ(${halfWidth})`, 
       text: `Охрана бизнеса`, 
       TypeText:`От 15 000 тг в месяц...`,
       imageUrl: imgBS,
@@ -91,8 +98,8 @@ const ismobile = useismobile();
       { 
 
       color: `rgb(0, 110, 255)`, 
-      width: width, height: width, 
-      font: `16px`, transform: `rotateY(-90deg) translateZ(${z})`, 
+      width: depth, height: height, 
+      font: `16px`, transform: `rotateY(-90deg) translateZ(${halfWidth})`, 
       text: `Особые услуги`, 
       TypeText:`Цена договорная...`,
       imageUrl: imgP,
@@ -101,12 +108,20 @@ const ismobile = useismobile();
       speed: 60,
       link: '/special_service'
     },
-      { color: `black`, width: width, height: width, font: `16px`, transform: `rotateX(90deg) translateZ(${z})`, 
+      { color: `black`, width: width, height: depth, font: `16px`, transform: `rotateX(90deg) translateZ(${halfHeight})`, 
       speed: 100 
     
     },
-      { color: `orange`, width: width, height: width, font: `16px`, transform: `rotateX(-90deg) translateZ(${z})`,},
+      { color: `orange`, width: width, height: depth, font: `16px`, transform: `rotateX(-90deg) translateZ(${halfHeight})`,},
     ];
   
-    return <Cube faces={cubeFaces} />;
+    return (
+      <Cube
+        faces={cubeFaces}
+        dimensions={{
+          width,
+          containerHeight: ismobile ? `${cubeDimensions.height + 4}ch` : '32ch',
+        }}
+      />
+    );
   };


### PR DESCRIPTION
### Motivation
- Make the 3D cube component adapt to mobile (vertical) screens by rendering a rectangular prism so faces/textures fit without distortion while preserving desktop visuals.
- Eliminate visible texture swap flicker during face rotations by preloading project images used on cube faces/sections.
- Fix a rotation state bug that could produce incorrect animation state and audit small performance/clarity issues.

### Description
- Updated `Cube` to accept `dimensions` (container width/height) and use those values for the cube container sizing instead of hard-coded values, and fixed the `animateCube` state update to remove an in-place assignment bug (`rotateX: -20` used instead of `rotateX: prev.rotateX = -20`).
- Reworked `TheCubes` face definitions to compute mobile vs desktop `cubeDimensions` (width, height, depth) and calculate per-face `width`, `height`, and `translateZ` offsets so a mobile rectangular prism is rendered while desktop keeps 1:1 cube proportions.
- Implemented image preloading in `ProjectsOtherSide` via `useEffect` and a small `window.Image` cache to ensure project images are loaded on mount to prevent on-demand loads during rotations.
- Kept desktop appearance and transforms unchanged for desktop breakpoints while only applying altered dimensions for mobile, and passed `containerHeight` through to `Cube` so container layout remains correct.

### Testing
- Launched the dev server with `npm run dev` and the app compiled successfully (Next dev started and served `/` with a 200 response). — succeeded.
- Captured a desktop rendering screenshot using Playwright scripting which completed and produced an artifact (`artifacts/cube-desktop.png`). — succeeded.
- Attempted a mobile viewport Playwright run but Chromium crashed in the environment (Playwright error / SIGSEGV), so automated mobile screenshot could not be captured here. — failed due to environment crash.
- No unit tests were present or executed; manual runtime checks above were used to validate compilation and desktop rendering. — compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69862ba0debc832b98da2f2cc3dcf39f)