### PR TITLE
Responsive mobile rectangular-prism for Cube, fix rotation mutation, and preload project images

### DIFF
--- a/src/app/components/Cube.js
+++ b/src/app/components/Cube.js
@@ -64,7 +64,7 @@ const CubeFace = ({ color, width, height, font, transform, text, TypeText, image
   </Box>
 );
 
-const Cube = ({ faces }) => {
+const Cube = ({ faces, containerWidth = '30ch', containerHeight = '32ch' }) => {
   const [rotation, setRotation] = useState({ rotateX: -30, rotateY: 30 });
   const [isInteracting, setIsInteracting] = useState(false);
   const isDragging = useRef(false);
@@ -104,7 +104,7 @@ const Cube = ({ faces }) => {
   const animateCube = () => {
     if (!isInteracting) {
       setRotation((prev) => ({
-        rotateX: prev.rotateX = - 20,
+        rotateX: -20,
         rotateY: prev.rotateY + 0.3,
       }));
     }
@@ -133,8 +133,8 @@ const Cube = ({ faces }) => {
       <Box
         sx={{
           position: 'relative',
-          width: '30ch',
-          height: '32ch',
+          width: containerWidth,
+          height: containerHeight,
           transformStyle: 'preserve-3d',
           transform: `rotateX(${rotation.rotateX}deg) rotateY(${rotation.rotateY}deg)`,
           transition: 'transform 0.1s linear',

--- a/src/app/components/ProjectsOtherSide.js
+++ b/src/app/components/ProjectsOtherSide.js
@@ -1,5 +1,5 @@
 'use client'
-import React from "react";
+import React, { useEffect } from "react";
 import { Box, Heading  } from "@chakra-ui/react";
 import useismobile from "@/hooks/isMobile";
 
@@ -113,6 +113,14 @@ const Why_box = ({ text, img, text2, dark = 'rgba(0, 0, 0, 0.5)' }) => {
 const ProjectsOtherSide = () => {
 
   const ismobile = useismobile()
+
+  useEffect(() => {
+    const sources = [img1, img2, img3, img4];
+    sources.forEach((src) => {
+      const preloadedImage = new window.Image();
+      preloadedImage.src = src;
+    });
+  }, []);
 
   return (
     <Box

--- a/src/app/components/TheCubes.js
+++ b/src/app/components/TheCubes.js
@@ -49,10 +49,29 @@ let img29 = "/images/typeeffect.webp";
 
 export const Cube1 = () => {
 const ismobile = useismobile();
-  const width = ismobile ? `30ch` : `30ch`;
-  const z = ismobile ? `15ch` : `15ch`;
+  const dimensions = ismobile
+    ? {
+        width: '28ch',
+        height: '36ch',
+        depth: '20ch',
+        halfWidth: '14ch',
+        halfHeight: '18ch',
+        halfDepth: '10ch',
+        containerHeight: '38ch',
+      }
+    : {
+        width: '30ch',
+        height: '30ch',
+        depth: '30ch',
+        halfWidth: '15ch',
+        halfHeight: '15ch',
+        halfDepth: '15ch',
+        containerHeight: '32ch',
+      };
+
+  const { width, height, depth, halfWidth, halfHeight, halfDepth, containerHeight } = dimensions;
     const cubeFaces = [
-      { color: `rgb(252, 226, 114)`, width: width, height: width, font: `16px`, transform: `rotateY(0deg) translateZ(${z})`, 
+      { color: `rgb(252, 226, 114)`, width: width, height: height, font: `16px`, transform: `rotateY(0deg) translateZ(${halfDepth})`, 
       text: `Охрана квартир`,
       TypeText:`Всего от 7000 тг в месяц...`,
       imageUrl: imgF,
@@ -66,8 +85,8 @@ const ismobile = useismobile();
       color: `
   rgb(252, 226, 114)
       `, 
-      width: width, height: width, 
-      font: `16px`, transform: `rotateY(180deg) translateZ(${z})`,
+      width: width, height: height, 
+      font: `16px`, transform: `rotateY(180deg) translateZ(${halfDepth})`,
       text: `Охрана домов`, 
       TypeText:`От 8000 тг в месяц...`,
       imageUrl: img2,
@@ -79,7 +98,7 @@ const ismobile = useismobile();
       { 
       color: `
     rgb(0, 110, 255)
-      `, width: width, height: width, font: `16px`, transform: `rotateY(90deg) translateZ(${z})`, 
+      `, width: depth, height: height, font: `16px`, transform: `rotateY(90deg) translateZ(${halfWidth})`, 
       text: `Охрана бизнеса`, 
       TypeText:`От 15 000 тг в месяц...`,
       imageUrl: imgBS,
@@ -91,8 +110,8 @@ const ismobile = useismobile();
       { 
 
       color: `rgb(0, 110, 255)`, 
-      width: width, height: width, 
-      font: `16px`, transform: `rotateY(-90deg) translateZ(${z})`, 
+      width: depth, height: height, 
+      font: `16px`, transform: `rotateY(-90deg) translateZ(${halfWidth})`, 
       text: `Особые услуги`, 
       TypeText:`Цена договорная...`,
       imageUrl: imgP,
@@ -101,12 +120,12 @@ const ismobile = useismobile();
       speed: 60,
       link: '/special_service'
     },
-      { color: `black`, width: width, height: width, font: `16px`, transform: `rotateX(90deg) translateZ(${z})`, 
+      { color: `black`, width: width, height: depth, font: `16px`, transform: `rotateX(90deg) translateZ(${halfHeight})`, 
       speed: 100 
     
     },
-      { color: `orange`, width: width, height: width, font: `16px`, transform: `rotateX(-90deg) translateZ(${z})`,},
+      { color: `orange`, width: width, height: depth, font: `16px`, transform: `rotateX(-90deg) translateZ(${halfHeight})`,},
     ];
   
-    return <Cube faces={cubeFaces} />;
+    return <Cube faces={cubeFaces} containerWidth={width} containerHeight={containerHeight} />;
   };


### PR DESCRIPTION
### Motivation
- Improve mobile UX by changing the cube geometry into a rectangular prism on narrow screens while preserving desktop appearance.
- Remove a rotation-state mutation that could produce unstable animation state and improve predictable auto-rotation.
- Prevent flicker/blank frames during project image swaps by preloading images used in rotations.

### Description
- Made the cube container configurable via `containerWidth` and `containerHeight` props in `src/app/components/Cube.js` and removed an in-place mutation in the auto-rotation `setRotation` updater to avoid state mutation (`rotateX: -20` instead of assigning to `prev.rotateX`).
- Implemented responsive face geometry in `src/app/components/TheCubes.js` by switching to a rectangular-prism layout on mobile with separate `width`, `height`, `depth`, and their half-values, and updated face transforms to use those computed translations; desktop retains the original cube proportions.
- Added an image preloading `useEffect` in `src/app/components/ProjectsOtherSide.js` that instantiates `new Image()` for the four rotation images so textures are loaded on initialization and swaps occur without blank frames.

### Testing
- Started the Next.js development server via `next dev`, which compiled the app successfully (fallback font was used after Google Fonts fetch retries), and served the site (`GET / 200`).
- Ran a Playwright script that navigated to `http://127.0.0.1:3000`, captured a desktop screenshot, and produced an artifact (`artifacts/cube-desktop.png`) confirming the app renders; the Playwright run completed successfully.
- No automated unit tests were added or run for visual changes; compilation and runtime checks succeeded with the noted font fallback warning.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69862ba0debc832b98da2f2cc3dcf39f)